### PR TITLE
Feature/pipe types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Desmond is a caretaker of boilerplate code for node back-end development, providing a set of maintained tools.",
   "version": "0.4.0",
   "author": "Jaroslav Šmolík <grissius@gmail.com>",
+  "contributors": [
+    "Jiří Šmolík <smolikjirka@gmail.com>"
+  ],
   "main": "./dist/main.js",
   "engines": {
     "node": "^8.12.0"

--- a/src/lib/pipe.ts
+++ b/src/lib/pipe.ts
@@ -1,22 +1,78 @@
-import {
-    ArgType,
-    LastIndexOf,
-    Lookup,
-    ReplaceReturnTypePromise,
-    Tail,
-    UnpackPromise,
-    VariadicFunction,
-} from './internal/metaTypes';
-type RiverFn = (arg: any) => any;
-type AsChain<F extends [RiverFn, ...RiverFn[]], G extends RiverFn[] = Tail<F>> = {
-    [K in keyof F]: (arg: UnpackPromise<ArgType<F[K]>>) => ArgType<Lookup<G, K, any>, any>
-};
-function pipe<T>(): (arg: T) => Promise<T>;
-function pipe<Delta extends VariadicFunction>(df: Delta): Delta;
-function pipe<
-    Delta extends VariadicFunction,
-    F extends [(arg: UnpackPromise<ReturnType<Delta>>) => any, ...Array<(arg: any) => any>]
->(df: Delta, ...rivers: F & AsChain<F>): ReplaceReturnTypePromise<Delta, ReturnType<F[LastIndexOf<F>]>>;
+import { UnpackPromise } from './internal/metaTypes';
+type DeltaFn<ARG extends any[], R> = (...args: UnpackPromise<ARG>) => R | PromiseLike<R>;
+type RiverFn<ARG, R> = (arg: UnpackPromise<ARG>) => R | PromiseLike<R>;
+function pipe<A extends any[]>(): (...args: A) => UnpackPromise<A>;
+function pipe<A extends any[], R1>(f1: DeltaFn<A, R1>): (...args: A) => Promise<R1>;
+function pipe<A extends any[], R1, R2>(f1: DeltaFn<A, R1>, f2: RiverFn<R1, R2>): (...args: A) => Promise<R2>;
+function pipe<A extends any[], R1, R2, R3>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>
+): (...args: A) => Promise<R3>;
+function pipe<A extends any[], R1, R2, R3, R4>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>
+): (...args: A) => Promise<R4>;
+function pipe<A extends any[], R1, R2, R3, R4, R5>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>
+): (...args: A) => Promise<R5>;
+function pipe<A extends any[], R1, R2, R3, R4, R5, R6>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>,
+    f6: RiverFn<R5, R6>
+): (...args: A) => Promise<R6>;
+function pipe<A extends any[], R1, R2, R3, R4, R5, R6, R7>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>,
+    f6: RiverFn<R5, R6>,
+    f7: RiverFn<R6, R7>
+): (...args: A) => Promise<R7>;
+function pipe<A extends any[], R1, R2, R3, R4, R5, R6, R7, R8>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>,
+    f6: RiverFn<R5, R6>,
+    f7: RiverFn<R6, R7>,
+    f8: RiverFn<R7, R8>
+): (...args: A) => Promise<R8>;
+function pipe<A extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R9>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>,
+    f6: RiverFn<R5, R6>,
+    f7: RiverFn<R6, R7>,
+    f8: RiverFn<R7, R8>,
+    f9: RiverFn<R8, R9>
+): (...args: A) => Promise<R9>;
+function pipe<A extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R9, R10>(
+    f1: DeltaFn<A, R1>,
+    f2: RiverFn<R1, R2>,
+    f3: RiverFn<R2, R3>,
+    f4: RiverFn<R3, R4>,
+    f5: RiverFn<R4, R5>,
+    f6: RiverFn<R5, R6>,
+    f7: RiverFn<R6, R7>,
+    f8: RiverFn<R7, R8>,
+    f9: RiverFn<R8, R9>,
+    f10: RiverFn<R9, R10>
+): (...args: A) => Promise<R10>;
+function pipe(deltaFn: DeltaFn<any, any>, ...riverFns: Array<RiverFn<any, any>>): (...args: any) => Promise<any>;
 
 /**
  * Create a function composed of provided functions in left-to-right execution chain.

--- a/src/test/pipe.test.ts
+++ b/src/test/pipe.test.ts
@@ -66,6 +66,9 @@ describe('pipe', () => {
             always(1),
             always(1),
             always(1),
+            always(1),
+            always(1),
+            always(1),
             always(1)
         );
         await expect(longPipe()).resolves.toEqual(1);


### PR DESCRIPTION
After all the struggling with the pipe types, I think we should do a proper types at least for some arity, like lodash or ramda does.

This should fix inference in river functions up to 10 functions, as written [here](https://www.ackee.cz/blog/en/typescript/)

The solution uses tuples for pipe's functions arity according to [This SO Question](https://stackoverflow.com/questions/54212552/funciton-composition-in-typescript-without-overloads)